### PR TITLE
Highlighting missing buildings

### DIFF
--- a/AnnoCalculator.js
+++ b/AnnoCalculator.js
@@ -54,6 +54,7 @@ class Factory extends NamedElement {
         this.boost = ko.computed(() => parseInt(this.percentBoost()) / 100);
         this.demands = new Set();
         this.buildings = ko.computed(() => parseFloat(this.amount()) / this.tpmin / this.boost());
+        this.existingBuildings = ko.observable(0);
 
         this.workforceDemand = this.getWorkforceDemand();
         this.buildings.subscribe(val => this.workforceDemand.updateAmount(val));
@@ -346,6 +347,8 @@ function reset() {
             a.fixedFactory(null);
         if (a instanceof Factory)
             a.percentBoost(100);
+        if (a instanceof Factory)
+            a.existingBuildings(0);
         if (a instanceof PopulationLevel)
             a.amount(0);
     });
@@ -420,6 +423,14 @@ function init() {
                 f.percentBoost(parseInt(localStorage.getItem(id)));
 
             f.percentBoost.subscribe(val => localStorage.setItem(id, val));
+        }
+
+        if (localStorage) {
+            let id = f.guid + ".existingBuildings";
+            if (localStorage.getItem(id))
+                f.existingBuildings(parseInt(localStorage.getItem(id)));
+
+            f.existingBuildings.subscribe(val => localStorage.setItem(id, val));
         }
     }
 
@@ -555,6 +566,14 @@ texts = {
     requiredNumberOfBuildings: {
         english: "Required Number of Buildings",
         german: "Benötigte Anzahl an Gebäuden"
+    },
+    existingNumberOfBuildings: {
+        english: "Existing Number of Buildings",
+        german: "Vorhandene Anzahl an Gebäuden"
+    },
+    existingNumberOfBuildingsIs: {
+        english: "Is:",
+        german: "Ist:"
     },
     tonsPerMinute: {
         english: "Production in Tons per Minute",

--- a/AnnoCalculator.js
+++ b/AnnoCalculator.js
@@ -675,6 +675,13 @@ options = {
             "german": "Zeige Nachkommastellen bei der Gebäudeanzahl"
         }
     },
+    "missingBuildingsHighlight": {
+        "name": "Highlight missing buildings",
+        "locaText": {
+            "english": "Highlight missing buildings",
+            "german": "Fehlende Gebäude hervorheben"
+        }
+    },
     "hideNames": {
         "name": "Hide the names of products, factories, and population levels",
         "locaText": {

--- a/index.html
+++ b/index.html
@@ -215,7 +215,7 @@
                         <div data-bind="foreach: factories">
                             <div>
 
-                                <div class="ui-fchain-item" data-bind="visible: amount() > 0 || $data.editable && (!$root.settings.hideNewWorldConstructionMaterial.checked() || $data.region.guid === 5000000)">
+                                <div class="ui-fchain-item" data-bind="visible: amount() > 0 || $data.editable && (!$root.settings.hideNewWorldConstructionMaterial.checked() || $data.region.guid === 5000000), css: buildings() > existingBuildings() ? 'danger' : ''">
                                     <div class="ui-fchain-item-name" data-bind="text: $data.getRegionExtendedName(), visible: !$root.settings.hideNames.checked()"></div>
                                     <div class="ui-fchain-item-icon"><img src="" data-bind="attr: { src: $data.icon ? icon : null, alt: name }"></div>
                                     <div class="ui-fchain-item-count">
@@ -256,6 +256,17 @@
                                                 </div>
                                             </div>
 
+                                        </div>
+                                    </div>
+                                    <div class="ui-fchain-item-count" data-bind="if: !$data.editable">
+                                        <div href="#" data-toggle="tooltip" data-bind="attr: {'title' : $root.texts.existingNumberOfBuildings.name}">
+                                            <span data-bind="text: $root.texts.existingNumberOfBuildingsIs.name"></span>
+                                            <span data-bind="text: existingBuildings()"></span>
+                                            <span>x</span>
+                                            <div class="btn-group" role="group">
+                                                <button type="button" class="btn btn-secondary" data-bind="click: () => existingBuildings(parseInt(existingBuildings() + 1))" style="padding: 0em 0.25em 0em 0.25em; font-size: unset;">+</button>
+                                                <button type="button" class="btn btn-secondary" data-bind="click: () => existingBuildings(parseInt(existingBuildings() - 1)), enable: existingBuildings() >= 1" style="padding: 0em 0.25em 0em 0.25em; font-size: unset;">-</button>
+                                            </div>
                                         </div>
                                     </div>
                                     <div href="#" data-toggle="tooltip" data-bind="attr: {'title' : $root.texts.tonsPerMinute.name}">

--- a/index.html
+++ b/index.html
@@ -215,7 +215,7 @@
                         <div data-bind="foreach: factories">
                             <div>
 
-                                <div class="ui-fchain-item" data-bind="visible: amount() > 0 || $data.editable && (!$root.settings.hideNewWorldConstructionMaterial.checked() || $data.region.guid === 5000000), css: buildings() > existingBuildings() ? 'danger' : ''">
+                                <div class="ui-fchain-item" data-bind="visible: amount() > 0 || $data.editable && (!$root.settings.hideNewWorldConstructionMaterial.checked() || $data.region.guid === 5000000), css: $root.settings.missingBuildingsHighlight.checked() && buildings() > existingBuildings() ? 'danger' : ''">
                                     <div class="ui-fchain-item-name" data-bind="text: $data.getRegionExtendedName(), visible: !$root.settings.hideNames.checked()"></div>
                                     <div class="ui-fchain-item-icon"><img src="" data-bind="attr: { src: $data.icon ? icon : null, alt: name }"></div>
                                     <div class="ui-fchain-item-count">
@@ -258,7 +258,7 @@
 
                                         </div>
                                     </div>
-                                    <div class="ui-fchain-item-count" data-bind="if: !$data.editable">
+                                    <div class="ui-fchain-item-count" data-bind="if: !$data.editable && $root.settings.missingBuildingsHighlight.checked()">
                                         <div href="#" data-toggle="tooltip" data-bind="attr: {'title' : $root.texts.existingNumberOfBuildings.name}">
                                             <span data-bind="text: $root.texts.existingNumberOfBuildingsIs.name"></span>
                                             <span data-bind="text: existingBuildings()"></span>

--- a/index.html
+++ b/index.html
@@ -215,7 +215,7 @@
                         <div data-bind="foreach: factories">
                             <div>
 
-                                <div class="ui-fchain-item" data-bind="visible: amount() > 0 || $data.editable && (!$root.settings.hideNewWorldConstructionMaterial.checked() || $data.region.guid === 5000000), css: $root.settings.missingBuildingsHighlight.checked() && buildings() > existingBuildings() ? 'danger' : ''">
+                                <div class="ui-fchain-item" data-bind="visible: amount() > 0 || $data.editable && (!$root.settings.hideNewWorldConstructionMaterial.checked() || $data.region.guid === 5000000), css: $root.settings.missingBuildingsHighlight.checked() && !$data.editable && buildings() > existingBuildings() ? 'danger' : ''">
                                     <div class="ui-fchain-item-name" data-bind="text: $data.getRegionExtendedName(), visible: !$root.settings.hideNames.checked()"></div>
                                     <div class="ui-fchain-item-icon"><img src="" data-bind="attr: { src: $data.icon ? icon : null, alt: name }"></div>
                                     <div class="ui-fchain-item-count">

--- a/style.css
+++ b/style.css
@@ -80,6 +80,10 @@ h1 {
     border-radius: 4px;
     padding: 10px;
 }
+.ui-fchain-item.danger {
+    border-color: #FF0000;
+    background-color: #FFBBBB;
+}
 
 .ui-fchain-item-icon {
     text-align: center;


### PR DESCRIPTION
Hello!

I always had struggle after updating my inhabitants count to see, what buildings reached the "one more building needed to satisfy all needs" point. 

For this, I implemented an option to be able to input the buildings counts you already have. Now, when your own buildings count is lower than the needed buildings count, the building box is highlighted in red, so you directly see, what buildings you have to build to cover the needs of your inhabitants again.

Feel free to tell me your feedback on this feature (if you like it, why not, etc).

Thanks for the great app! Really handy :)

![missingBuildings](https://user-images.githubusercontent.com/135651/57582785-305a8d00-74c9-11e9-9316-4e4822be7ab5.PNG)