### PR TITLE
Fix for required construction material buildings when adding extra demand.

### DIFF
--- a/AnnoCalculator.js
+++ b/AnnoCalculator.js
@@ -671,7 +671,8 @@ class Consumer extends NamedElement {
         this.demands.forEach(d => {
             var a = d.amount();
             //            if (a <= -ACCURACY || a > 0)
-            sum += a;
+            if (!(d instanceof BuildingMaterialsNeed))
+                sum += a;
         });
 
         if (this.extraDemand && sum + this.extraDemand.amount() < -ACCURACY) {
@@ -2444,7 +2445,10 @@ class ProductionChainView {
             var chain = [];
             let traverse = d => {
                 if (d.factory && d.amount) {
-                    var a = ko.isObservable(d.amount) ? parseFloat(d.amount()) : parseFloat(d.amount);
+                    var a = 0
+                    if(!(d instanceof BuildingMaterialsNeed))
+                        a = ko.isObservable(d.amount) ? parseFloat(d.amount()) : parseFloat(d.amount);
+
                     var f = ko.isObservable(d.factory) ? d.factory() : d.factory;
                     if (Math.abs(a) < ACCURACY)
                         return;


### PR DESCRIPTION
Fix for issue #54 

NOTE: The production chains in the factory config dialog now show only the required buildings for the extra demand, as there is no regular demand for these. This only affects the construction material factories as the normal factories only work with needed demand anyways.

I haven't tested this thoroughly so there might be some side-effects I am not aware of. I wanted to share my fix regardless, as it might help with debugging when it turns out it does have side-effects.